### PR TITLE
Publish v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 # Changelog
-
 ## v0.0.3 Beta / 2023-12-26
 
 ### 🛑 Breaking changes 🛑

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coralogix-aws-shipper"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 
 [dependencies]

--- a/template.yaml
+++ b/template.yaml
@@ -23,7 +23,7 @@ Metadata:
       - cloudtrail
       - vpc
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 0.0.2
+    SemanticVersion: 0.0.3
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-shipper
 
   AWS::CloudFormation::Interface:


### PR DESCRIPTION
# Description

Fixes #
- Update the CoralogixRegion param list to be the same as the list in the https://coralogix.com/docs/coralogix-domain/
- Moved internal logic to lib.rs and Added Integration tests
- Added s3_key variable for app and subsystem name
- Fixed readme badge link for version
- Reduce Secret Manage IAM permissions
- Added default App or Subsystem name.

# How Has This Been Tested?
This is a publish

# Checklist:
- [X] I have updated the versions in the SemanticVersion in template.yaml
- [X] I have updated the CHANGELOG.md
- [ ] I have created necessary PR to Terraform Module Repository (https://github.com/coralogix/terraform-coralogix-aws) if needed
- [ ] This change does not affect any particular component (e.g. it's CI or docs change) 
