### PR TITLE
Fix region typo US --> US1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v0.0.10 Beta / 2024-01-17
+### 🧰 Bug fixes 🧰
+- Fix typo in Coralogix region selection US --> US1
+
 ## v0.0.9 Beta / 2024-01-16
 ### 🚀 New components 🚀
 - Added support for Cloudfront Access logs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coralogix-aws-shipper"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ https://github.com/coralogix/terraform-coralogix-aws/tree/master/modules/coralog
 |---|---|---|---|
 | Application name | The stack name of this application created via AWS CloudFormation. |   | :heavy_check_mark: |
 | IntegrationType | The integration type. Can be one of: S3, CloudTrail, VpcFlow, CloudWatch, S3Csv, Sns, Sqs, Kinesis, CloudFront' |  S3 | :heavy_check_mark: | 
-| CoralogixRegion | The Coralogix location region, possible options are [Custom, EU1, EU2, AP1, AP2, US, US2] If this value is set to Custom you must specify the Custom Domain to use via the CustomDomain parameter |  Custom | :heavy_check_mark: | 
+| CoralogixRegion | The Coralogix location region, possible options are [Custom, EU1, EU2, AP1, AP2, US1, US2] If this value is set to Custom you must specify the Custom Domain to use via the CustomDomain parameter |  Custom | :heavy_check_mark: | 
 | CustomDomain | The Custom Domain. If set, will be the domain used to send telemetry (e.g. cx123.coralogix.com) |   |   |
 | ApplicationName | The [name](https://coralogix.com/docs/application-and-subsystem-names/) of your application. For dynamically value check [Advanced section](#advanced)|   | :heavy_check_mark: | 
 | SubsystemName | The [name](https://coralogix.com/docs/application-and-subsystem-names/) of your subsystem. For dynamic value from the check [Advanced section](#advanced). For Cloudwatch leave empty to use the loggroup name.|   |   |

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ https://github.com/coralogix/terraform-coralogix-aws/tree/master/modules/coralog
 | Parameter | Description | Default Value | Required |
 |---|---|---|---|
 | S3BucketName | The name of the AWS S3 bucket to watch |   | :heavy_check_mark: |
-| S3KeyPrefix | The AWS S3 path prefix to watch. This value is ignored when the SNSTopicArn parameter is provided. | CloudTrail/VpcFlow 'AWSLogs/' |   |
-| S3KeySuffix | The AWS S3 path suffix to watch. This value is ignored when the SNSTopicArn parameter is provided. | CloudTrail '.json.gz',  VpcFlow '.log.gz' |   |
+| S3KeyPrefix | The AWS S3 path prefix to watch. This value is ignored if you use the SQS/SNSTopicArn parameter. | CloudTrail/VpcFlow 'AWSLogs/' |   |
+| S3KeySuffix | The AWS S3 path suffix to watch. This value is ignored if you use the SQS/SNSTopicArn parameter. | CloudTrail '.json.gz',  VpcFlow '.log.gz' |   |
 | NewlinePattern | Regular expression to detect a new log line for multiline logs from S3 source, e.g., use expression \n(?=\d{2}\-\d{2}\s\d{2}\:\d{2}\:\d{2}\.\d{3}) |   |   |
 | SNSTopicArn | The ARN for the SNS topic that contains the SNS subscription responsible for retrieving logs from Amazon S3 |   |   |
 | SQSTopicArn | The ARN for the SQS queue that contains the SQS subscription responsible for retrieving logs from Amazon S3 |   |   |

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ To use privatelink please forllow the instruction in this [link](https://coralog
 
 - Look out for TimeOut Errors "Task timed out after", if you see them, please increase lambda timeout from Configuration -> General Configuration
 - Look out for out of Memory logs "Task out of Memory" , if you see them, please increase lambda max memory from Configuration -> General Configuration
-- To add more verbosity to Lambda logs, you can set RUST_LOG to DEBUG. Remamber to change it back to INFO once troubleshooting is done.
+- To add more verbosity to Lambda logs, you can set RUST_LOG to DEBUG. Remamber to change it back to WARN once troubleshooting is done.
 - set MAX_ELAPSED_TIME variable for default change ( default = 250 )
 - Set BATCHES_MAX_SIZE (in MB) sets batch max size before sending to coralogix. This value is limited by the max payload accepted by Coralogix Endpoing. (default = 4)
 - Set BATCHES_MAX_CONCURRENCY sets max amount of concurrect batches can be sent. 

--- a/template.yaml
+++ b/template.yaml
@@ -102,14 +102,14 @@ Parameters:
   CoralogixRegion:
     Type: String
     Description: |
-      The Coralogix location region, possible options are [EU1, EU2, AP1, AP2, US, US2]
+      The Coralogix location region, possible options are [EU1, EU2, AP1, AP2, US1, US2]
       If this value is set to Custom you must specify the Custom Domain to use via the CustomDomain parameter.
     AllowedValues:
       - EU1
       - EU2
       - AP1
       - AP2
-      - US
+      - US1
       - US2
       - Custom
     Default: Custom
@@ -305,7 +305,7 @@ Mappings:
       Domain: coralogix.in
     AP2:
       Domain: coralogixsg.com
-    US:
+    US1:
       Domain: coralogix.us
     US2:
       Domain: cx498.coralogix.com

--- a/template.yaml
+++ b/template.yaml
@@ -26,7 +26,7 @@ Metadata:
       - kinesis
       - cloudfront
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 0.0.9
+    SemanticVersion: 0.0.10
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-shipper
 
   AWS::CloudFormation::Interface:

--- a/template.yaml
+++ b/template.yaml
@@ -102,7 +102,7 @@ Parameters:
   CoralogixRegion:
     Type: String
     Description: |
-      The Coralogix location region, possible options are [EU1, EU2, AP1, AP2, US1, US2]
+      The Coralogix location region, possible options are [EU1, EU2, AP1, AP2, US1, US2, Custom]
       If this value is set to Custom you must specify the Custom Domain to use via the CustomDomain parameter.
     AllowedValues:
       - EU1


### PR DESCRIPTION
# Description
Fix typo in region selection option

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the versions in the SemanticVersion in template.yaml
- [x] I have updated the CHANGELOG.md
- [ ] I have created necessary PR to Terraform Module Repository (https://github.com/coralogix/terraform-coralogix-aws) if needed
- [ ] This change does not affect any particular component (e.g. it's CI or docs change) 
