### PR TITLE
add support for multiple msk topic [CDS-1108]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+### 💡 Enhancements 💡
+- Support multiple topics for msk integration
+
 ## v1.0.3 / 
 ### 🚀 New components 🚀
 - Custom Metadata can be added to the log messages.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Your Lambda function must be in a VPC that has access to the MSK cluster. You ca
 | Parameter  | Description                                         | Default Value | Required           |
 |------------|-----------------------------------------------------|---------------|--------------------|
 | MSKBrokers | Comma-delimited list of MSK brokers to connect to.  |               | :heavy_check_mark: |
-| KafkaTopic | Subscribe to this Kafka topic for data consumption. |               | :heavy_check_mark: |
+| KafkaTopic | Comma separated list of Kafka topics to Subscribe to. |               | :heavy_check_mark: |
 
 ### Generic Configuration (Optional)
 

--- a/template.yaml
+++ b/template.yaml
@@ -1031,15 +1031,25 @@ Resources:
         DestinationConfig:
           OnFailure:
             Type: SNS
-      Events:
-        MSKEvent:
-          Type: MSK
-          Properties:
-            Stream: !Ref MSKClusterArn
-            StartingPosition: LATEST
+      # Events:
+      #   MSKEvent:
+      #     Type: MSK
+      #     Properties:
+      #       Stream: !Ref MSKClusterArn
+      #       StartingPosition: LATEST
             
-            Topics: 
-              - !Ref KafkaTopic
+      #       Topics: 
+      #         - !Ref KafkaTopic
+      
+  LambdaTriggerMskTopic:
+    Condition: UseMSK
+    Type: Custom::LambdaTrigger
+    DependsOn: LambdaFunctionWithMSK
+    Properties:
+      ServiceToken: !GetAtt [ CustomResourceLambdaTriggerFunction, Arn ]
+      LambdaName: !GetAtt [ 'LambdaFunctionWithMSK', Arn ]
+      MSKClusterArn: !Ref MSKClusterArn
+      TopicsList: !Ref KafkaTopic
 
   LambdaLogGroupMSK:
     Condition: UseMSK
@@ -1246,187 +1256,229 @@ Resources:
                         {},
                         event.get('PhysicalResourceId', context.aws_request_id)
                     )
-        - !If 
-          - IsKafkaIntegration
+        - !If
+          - UseMSK
           - |
-              #!/usr/bin/python
-              # -*- coding: utf-8 -*-
-              import json, time, boto3
-              from urllib import request, parse, error
+            import json
+            import boto3
+            import cfnresponse
 
-              class CFNResponse:
-                  '''
-                  CFNResponse class, temporary class used to handle cloudformation responses
-                  as currently lambda has an issue importing cfnresponse module.
-                  '''
-                  SUCCESS = "SUCCESS"
-                  FAILED = "FAILED"
+            print("Loading function")
 
-                  def __init__(self, event, context):
-                      self.event = event
-                      self.context = context
-                      self.response_url = event['ResponseURL']
+            def lambda_handler(event, context):
+                print("Received event:", json.dumps(event, indent=2))
+                try:        
+                    lambda_name = event['ResourceProperties']['LambdaName']
+                    msk_cluster_arn = event['ResourceProperties']['MSKClusterArn']
+                    lambda_client = boto3.client('lambda')
+                    if event['RequestType'] in ['Create', 'Update']:
+                        TopicsListString = event['ResourceProperties']['TopicsList']
+                        TopicsList = TopicsListString.split(',')
+                        for topic in TopicsList:
+                            response = lambda_client.create_event_source_mapping(
+                                EventSourceArn=msk_cluster_arn,
+                                FunctionName=lambda_name,
+                                Topics=[
+                                    topic
+                                ],
+                                StartingPosition='LATEST',
+                                BatchSize=100,
+                            )
+                    responseStatus = cfnresponse.SUCCESS
+                    print(event['RequestType'], "request completed....")
+                except Exception as e:
+                    print("Failed to process:", e)
+                    responseStatus = cfnresponse.FAILED
+                finally:
+                    print("Sending response to custom resource")
+                    cfnresponse.send(
+                        event,
+                        context,
+                        responseStatus,
+                        {},
+                        event.get('PhysicalResourceId', context.aws_request_id)
+                    )
+          - !If 
+            - IsKafkaIntegration
+            - |
+                #!/usr/bin/python
+                # -*- coding: utf-8 -*-
+                import json, time, boto3
+                from urllib import request, parse, error
 
-                  def send(self, status, response_data, physical_resource_id=None, no_echo=False, reason=None):
-                      response_body = {
-                          'Status': status,
-                          'Reason': reason or "See the details in CloudWatch Log Stream: {}".format(self.context.log_stream_name),
-                          'PhysicalResourceId': physical_resource_id or self.context.log_stream_name,
-                          'StackId': self.event['StackId'],
-                          'RequestId': self.event['RequestId'],
-                          'LogicalResourceId': self.event['LogicalResourceId'],
-                          'NoEcho': no_echo,
-                          'Data': response_data
-                      }
-                      json_response_body = json.dumps(response_body).encode('utf-8')
-                      headers = {
-                          'content-type': '',
-                          'content-length': str(len(json_response_body))
-                      }
-                      try:
-                          req = request.Request(self.response_url, data=json_response_body, headers=headers, method='PUT')
-                          with request.urlopen(req) as response:
-                              print("Status code:", response.getcode())
-                              print("Response:", response.read().decode('utf-8'))
-                      except error.HTTPError as e:
-                          print("HTTPError:", e.reason)
-                          print("Status code:", e.code)
-                      except error.URLError as e:
-                          print("URLError:", e.reason)
+                class CFNResponse:
+                    '''
+                    CFNResponse class, temporary class used to handle cloudformation responses
+                    as currently lambda has an issue importing cfnresponse module.
+                    '''
+                    SUCCESS = "SUCCESS"
+                    FAILED = "FAILED"
 
-              client = boto3.client("lambda")
+                    def __init__(self, event, context):
+                        self.event = event
+                        self.context = context
+                        self.response_url = event['ResponseURL']
 
-              def delete_event_source_mappings(function_name):
-                  mappings = client.list_event_source_mappings(
-                      FunctionName=function_name,
-                  )["EventSourceMappings"]
-                  for mapping in mappings:
-                      # disable mapping
-                      if mapping["State"] == "Enabled":
-                          client.update_event_source_mapping(
-                              UUID=mapping["UUID"],
-                              FunctionName=function_name,
-                              Enabled=False
-                          )
-                      time.sleep(10) # wait for mapping to be disabled
-                      client.delete_event_source_mapping(UUID=mapping["UUID"])
+                    def send(self, status, response_data, physical_resource_id=None, no_echo=False, reason=None):
+                        response_body = {
+                            'Status': status,
+                            'Reason': reason or "See the details in CloudWatch Log Stream: {}".format(self.context.log_stream_name),
+                            'PhysicalResourceId': physical_resource_id or self.context.log_stream_name,
+                            'StackId': self.event['StackId'],
+                            'RequestId': self.event['RequestId'],
+                            'LogicalResourceId': self.event['LogicalResourceId'],
+                            'NoEcho': no_echo,
+                            'Data': response_data
+                        }
+                        json_response_body = json.dumps(response_body).encode('utf-8')
+                        headers = {
+                            'content-type': '',
+                            'content-length': str(len(json_response_body))
+                        }
+                        try:
+                            req = request.Request(self.response_url, data=json_response_body, headers=headers, method='PUT')
+                            with request.urlopen(req) as response:
+                                print("Status code:", response.getcode())
+                                print("Response:", response.read().decode('utf-8'))
+                        except error.HTTPError as e:
+                            print("HTTPError:", e.reason)
+                            print("Status code:", e.code)
+                        except error.URLError as e:
+                            print("URLError:", e.reason)
 
-              def lambda_handler(event, context):
-                  print("Received event:", json.dumps(event, indent=2))
-                  cfn = CFNResponse(event, context)
-                  responseStatus = CFNResponse.SUCCESS
-                  physicalResourceId = event.get("PhysicalResourceId")
-                  function_name = event["ResourceProperties"]["Function"]
-                  try:
-                      print("Request Type:", event["RequestType"])
-                      if event["RequestType"] in ["Create", "Update"]:
-                          if event["RequestType"] == "Update":
-                              print('Update event detected, deleting previous mapping(s)')
-                              delete_event_source_mappings(function_name)
-                          response = client.create_event_source_mapping(
-                              FunctionName=event["ResourceProperties"]["Function"],
-                              BatchSize=int(event["ResourceProperties"]["BatchSize"]),
-                              StartingPosition=event["ResourceProperties"]["StartingPosition"],
-                              Topics=[
-                                  event["ResourceProperties"]["Topic"]
-                              ],
-                              SelfManagedEventSource={
-                                  "Endpoints": {
-                                      "KAFKA_BOOTSTRAP_SERVERS": event["ResourceProperties"]["Brokers"]
-                                  }
-                              },
-                              SourceAccessConfigurations=list([
-                                  {
-                                      "Type": "VPC_SUBNET",
-                                      "URI": "subnet:" + subnetId
-                                  } for subnetId in event["ResourceProperties"]["SubnetIds"]
-                              ]) + list([
-                                  {
-                                      "Type": "VPC_SECURITY_GROUP",
-                                      "URI": "security_group:" + securityGroupId
-                                  } for securityGroupId in event["ResourceProperties"]["SecurityGroupIds"]
-                              ])
-                          )
-                          physicalResourceId = response["UUID"]
-                          print(f"EventSourceMapping successfully created: {physicalResourceId}")
-                      elif event["RequestType"] == "Delete":
-                          delete_event_source_mappings(function_name)
-                          print("EventSourceMapping successfully deleted")
-                  except Exception as exc:
-                      print("Failed to process:", exc)
-                      responseStatus = CFNResponse.FAILED
-                  finally:
-                      cfn.send(responseStatus, {}, physical_resource_id=physicalResourceId)
-          - |
-              #!/usr/bin/python
-              # -*- coding: utf-8 -*-
+                client = boto3.client("lambda")
 
-              import json
-              import boto3
-              import cfnresponse
+                def delete_event_source_mappings(function_name):
+                    mappings = client.list_event_source_mappings(
+                        FunctionName=function_name,
+                    )["EventSourceMappings"]
+                    for mapping in mappings:
+                        # disable mapping
+                        if mapping["State"] == "Enabled":
+                            client.update_event_source_mapping(
+                                UUID=mapping["UUID"],
+                                FunctionName=function_name,
+                                Enabled=False
+                            )
+                        time.sleep(10) # wait for mapping to be disabled
+                        client.delete_event_source_mapping(UUID=mapping["UUID"])
 
-              print("Loading function")
-              s3 = boto3.client('s3')
+                def lambda_handler(event, context):
+                    print("Received event:", json.dumps(event, indent=2))
+                    cfn = CFNResponse(event, context)
+                    responseStatus = CFNResponse.SUCCESS
+                    physicalResourceId = event.get("PhysicalResourceId")
+                    function_name = event["ResourceProperties"]["Function"]
+                    try:
+                        print("Request Type:", event["RequestType"])
+                        if event["RequestType"] in ["Create", "Update"]:
+                            if event["RequestType"] == "Update":
+                                print('Update event detected, deleting previous mapping(s)')
+                                delete_event_source_mappings(function_name)
+                            response = client.create_event_source_mapping(
+                                FunctionName=event["ResourceProperties"]["Function"],
+                                BatchSize=int(event["ResourceProperties"]["BatchSize"]),
+                                StartingPosition=event["ResourceProperties"]["StartingPosition"],
+                                Topics=[
+                                    event["ResourceProperties"]["Topic"]
+                                ],
+                                SelfManagedEventSource={
+                                    "Endpoints": {
+                                        "KAFKA_BOOTSTRAP_SERVERS": event["ResourceProperties"]["Brokers"]
+                                    }
+                                },
+                                SourceAccessConfigurations=list([
+                                    {
+                                        "Type": "VPC_SUBNET",
+                                        "URI": "subnet:" + subnetId
+                                    } for subnetId in event["ResourceProperties"]["SubnetIds"]
+                                ]) + list([
+                                    {
+                                        "Type": "VPC_SECURITY_GROUP",
+                                        "URI": "security_group:" + securityGroupId
+                                    } for securityGroupId in event["ResourceProperties"]["SecurityGroupIds"]
+                                ])
+                            )
+                            physicalResourceId = response["UUID"]
+                            print(f"EventSourceMapping successfully created: {physicalResourceId}")
+                        elif event["RequestType"] == "Delete":
+                            delete_event_source_mappings(function_name)
+                            print("EventSourceMapping successfully deleted")
+                    except Exception as exc:
+                        print("Failed to process:", exc)
+                        responseStatus = CFNResponse.FAILED
+                    finally:
+                        cfn.send(responseStatus, {}, physical_resource_id=physicalResourceId)
+            - |
+                #!/usr/bin/python
+                # -*- coding: utf-8 -*-
 
-              def lambda_handler(event, context):
-                  print("Received event:", json.dumps(event, indent=2))
-                  bucket = event['ResourceProperties']['Bucket']
-                  print(f"processing bucket {bucket}")
-                  try:
-                      print("Request Type:", event['RequestType'])
-                      BucketNotificationConfiguration = s3.get_bucket_notification_configuration(
-                          Bucket=bucket
-                      )
-                      BucketNotificationConfiguration.pop('ResponseMetadata')
-                      BucketNotificationConfiguration.setdefault('LambdaFunctionConfigurations', [])
+                import json
+                import boto3
+                import cfnresponse
 
-                      if event['RequestType'] in ['Update', 'Delete']:
-                          BucketNotificationConfiguration['LambdaFunctionConfigurations'] = list(
-                              filter(
-                                  lambda configuration: configuration.get('Id') != event['PhysicalResourceId'],
-                                  BucketNotificationConfiguration['LambdaFunctionConfigurations']
-                              )
-                          )
-                      if event['RequestType'] in ['Create', 'Update']:
-                          BucketNotificationConfiguration['LambdaFunctionConfigurations'].append({
-                              'Id': event.get('PhysicalResourceId', context.aws_request_id),
-                              'LambdaFunctionArn': event['ResourceProperties']['LambdaArn'],
-                              'Filter': {
-                                  'Key': {
-                                      'FilterRules': [
-                                          {
-                                              'Name': 'prefix',
-                                              'Value': event['ResourceProperties'].get('Prefix', '')
-                                          },
-                                          {
-                                              'Name': 'suffix',
-                                              'Value': event['ResourceProperties'].get('Suffix', '')
-                                          },
-                                      ]
-                                  }
-                              },
-                              'Events': [
-                                  's3:ObjectCreated:*'
-                              ]
-                          })
-                      if len(BucketNotificationConfiguration['LambdaFunctionConfigurations']) == 0:
-                          BucketNotificationConfiguration.pop('LambdaFunctionConfigurations')
-                      print(f'nofication configuration: {BucketNotificationConfiguration}')
-                      s3.put_bucket_notification_configuration(
-                          Bucket=bucket,
-                          NotificationConfiguration=BucketNotificationConfiguration
-                      )
-                      responseStatus = cfnresponse.SUCCESS
-                      print(event['RequestType'], "request completed....")
-                  except Exception as e:
-                      print("Failed to process:", e)
-                      responseStatus = cfnresponse.FAILED
-                  finally:
-                      print("Sending response to custom resource")
-                      cfnresponse.send(
-                          event,
-                          context,
-                          responseStatus,
-                          {},
-                          event.get('PhysicalResourceId', context.aws_request_id)
-                      )
+                print("Loading function")
+                s3 = boto3.client('s3')
+
+                def lambda_handler(event, context):
+                    print("Received event:", json.dumps(event, indent=2))
+                    bucket = event['ResourceProperties']['Bucket']
+                    print(f"processing bucket {bucket}")
+                    try:
+                        print("Request Type:", event['RequestType'])
+                        BucketNotificationConfiguration = s3.get_bucket_notification_configuration(
+                            Bucket=bucket
+                        )
+                        BucketNotificationConfiguration.pop('ResponseMetadata')
+                        BucketNotificationConfiguration.setdefault('LambdaFunctionConfigurations', [])
+
+                        if event['RequestType'] in ['Update', 'Delete']:
+                            BucketNotificationConfiguration['LambdaFunctionConfigurations'] = list(
+                                filter(
+                                    lambda configuration: configuration.get('Id') != event['PhysicalResourceId'],
+                                    BucketNotificationConfiguration['LambdaFunctionConfigurations']
+                                )
+                            )
+                        if event['RequestType'] in ['Create', 'Update']:
+                            BucketNotificationConfiguration['LambdaFunctionConfigurations'].append({
+                                'Id': event.get('PhysicalResourceId', context.aws_request_id),
+                                'LambdaFunctionArn': event['ResourceProperties']['LambdaArn'],
+                                'Filter': {
+                                    'Key': {
+                                        'FilterRules': [
+                                            {
+                                                'Name': 'prefix',
+                                                'Value': event['ResourceProperties'].get('Prefix', '')
+                                            },
+                                            {
+                                                'Name': 'suffix',
+                                                'Value': event['ResourceProperties'].get('Suffix', '')
+                                            },
+                                        ]
+                                    }
+                                },
+                                'Events': [
+                                    's3:ObjectCreated:*'
+                                ]
+                            })
+                        if len(BucketNotificationConfiguration['LambdaFunctionConfigurations']) == 0:
+                            BucketNotificationConfiguration.pop('LambdaFunctionConfigurations')
+                        print(f'nofication configuration: {BucketNotificationConfiguration}')
+                        s3.put_bucket_notification_configuration(
+                            Bucket=bucket,
+                            NotificationConfiguration=BucketNotificationConfiguration
+                        )
+                        responseStatus = cfnresponse.SUCCESS
+                        print(event['RequestType'], "request completed....")
+                    except Exception as e:
+                        print("Failed to process:", e)
+                        responseStatus = cfnresponse.FAILED
+                    finally:
+                        print("Sending response to custom resource")
+                        cfnresponse.send(
+                            event,
+                            context,
+                            responseStatus,
+                            {},
+                            event.get('PhysicalResourceId', context.aws_request_id)
+                        )


### PR DESCRIPTION
# Description
Update the KafkaTopic for the msk integration to accept multiple topics, and add code to the custom lambda so in case custom will use the msk integration it will take the comma-separated list of topics and add them as a triggers to the lambda
<!-- Please describe the changes you made in a few words or sentences. -->
<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the versions in the SemanticVersion in template.yaml
- [x] I have updated the CHANGELOG.md
- [x] I have created necessary PR to Terraform Module Repository (https://github.com/coralogix/terraform-coralogix-aws) if needed
- [ ] This change does not affect any particular component (e.g. it's CI or docs change) 
