### PR TITLE
Cloudwatch integration update custom lambda [CDS-1136]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Custom Metadata can be added to the log messages.
 - Added Support for Custom CSV Header
 
+### 🧰 Bug fixes 🧰
+- Update CloudWatch custom lambda, so you will be able to see log group as trigger in the UI
+
 ## v1.0.2 / 2024-03-21
 ### 🧰 Bug fixes 🧰
 - Ecr integration lambda trigger bug fix

--- a/template.yaml
+++ b/template.yaml
@@ -1240,7 +1240,7 @@ Resources:
             import json
             import boto3
             import cfnresponse
-
+            import time
             print("Loading function")
 
             def lambda_handler(event, context):
@@ -1248,6 +1248,8 @@ Resources:
                 try:        
                     lambda_arn = event['ResourceProperties']['LambdaArn']
                     lambda_client = boto3.client('lambda')
+                    region = context.invoked_function_arn.split(":")[3]
+                    account_id = context.invoked_function_arn.split(":")[4]
                     StringlogGroupName = event['ResourceProperties']['CloudwatchGroup']
                     logGroupName = StringlogGroupName.split(',')
                     cloudwatch_logs = boto3.client('logs')
@@ -1260,14 +1262,34 @@ Resources:
                                     filterName='coralogix-aws-shipper-cloudwatch-trigger',
                                     logGroupName=log_group
                                 )
+                                response = lambda_client.remove_permission(
+                                    FunctionName=lambda_arn,
+                                    StatementId=f"allow-trigger-from-{log_group}"
+                                )
                     if event['RequestType'] in ['Create', 'Update']:
                         for log_group in logGroupName:
+                            cloudwatch_logs = boto3.client('logs')
+                            response = cloudwatch_logs.describe_subscription_filters(
+                              logGroupName=log_group,
+                              filterNamePrefix='coralogix-aws-shipper-cloudwatch-trigger'
+                            )
+                            if not response.get("subscriptionFilters") or response.get("subscriptionFilters")[0].get("destinationArn") != lambda_arn:
+                                response = lambda_client.add_permission(
+                                  FunctionName=lambda_arn,
+                                  StatementId=f'allow-trigger-from-{log_group}',
+                                  Action='lambda:InvokeFunction',
+                                  Principal='logs.amazonaws.com',
+                                  SourceArn=f'arn:aws:logs:{region}:{account_id}:log-group:{log_group}:*',
+                                )
+                            time.sleep(1)
                             cloudwatch_logs.put_subscription_filter(
                                 destinationArn=event['ResourceProperties']['LambdaArn'],
                                 filterName='coralogix-aws-shipper-cloudwatch-trigger',
                                 filterPattern='',
                                 logGroupName=log_group
                             )
+
+
                     responseStatus = cfnresponse.SUCCESS
                     print(event['RequestType'], "request completed....")
                 except Exception as e:

--- a/template.yaml
+++ b/template.yaml
@@ -877,7 +877,7 @@ Resources:
   LambdaTriggerCloudwatchLogs:
     Condition: UseCloudwatchLogs
     Type: Custom::LambdaTrigger
-    DependsOn: LambdaFunctionInvokePermissionCloudwatchLogs
+    # DependsOn: LambdaFunctionInvokePermissionCloudwatchLogs
     Properties:
       ServiceToken: !GetAtt [ CustomResourceLambdaTriggerFunction, Arn ]
       LambdaArn: !GetAtt [ 'LambdaFunctionCloudwatchLogs', Arn ]

--- a/template.yaml
+++ b/template.yaml
@@ -883,15 +883,15 @@ Resources:
       LambdaArn: !GetAtt [ 'LambdaFunctionCloudwatchLogs', Arn ]
       CloudwatchGroup: !Ref CloudWatchLogGroupName
 
-  LambdaFunctionInvokePermissionCloudwatchLogs:
-    Type: AWS::Lambda::Permission
-    Condition: UseCloudwatchLogs
-    Properties:
-      FunctionName: !GetAtt [ 'LambdaFunctionCloudwatchLogs', Arn ]
-      Action: lambda:InvokeFunction
-      Principal: logs.amazonaws.com
-      SourceAccount: !Ref AWS::AccountId
-      SourceArn: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*"
+  # LambdaFunctionInvokePermissionCloudwatchLogs:
+  #   Type: AWS::Lambda::Permission
+  #   Condition: UseCloudwatchLogs
+  #   Properties:
+  #     FunctionName: !GetAtt [ 'LambdaFunctionCloudwatchLogs', Arn ]
+  #     Action: lambda:InvokeFunction
+  #     Principal: logs.amazonaws.com
+  #     SourceAccount: !Ref AWS::AccountId
+  #     SourceArn: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*:*"
   
   ################################
   # ----- With SQS TopiC ------- #


### PR DESCRIPTION
There is a bug in AWS which in case you use wild card * for the permission to allow all log groups to trigger the lambdaת you will not see the log group as a trigger in the lambda.
Update the custom CloudWatch lambda to add permission for each log group before creating a subscription in the log group so it will now be possible to see the log group as a trigger.
<!-- Please describe the changes you made in a few words or sentences. -->
<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the versions in the SemanticVersion in template.yaml
- [x] I have updated the CHANGELOG.md
- [ ] I have created necessary PR to Terraform Module Repository (https://github.com/coralogix/terraform-coralogix-aws) if needed
- [ ] This change does not affect any particular component (e.g. it's CI or docs change) 
