### PR TITLE
update statmentId for the cloudwatch integrations[CDS-1408]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.0.11 / 2024-07-30
 ### 🧰 Bug fixes 🧰
-- fix bug when trying to deploy CloudWatch integration with log group, with a name longer than 70 letters.
+- fix bug when trying to deploy CloudWatch integration. deploy with log group, with a name longer than 70 letters hit a limit with aws permission length, update the function so in case that the name is longer than 70 letters it will take the first 65 letters and the last 5.
 
 ## v1.0.10 / 2024-07-23
 ### 💡 Enhancements 💡

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## v1.0.11 / 2024-07-30
+### 🧰 Bug fixes 🧰
+- fix bug when trying to deploy CloudWatch integration with log group, with a name longer than 70 letters.
+
 ## v1.0.10 / 2024-07-23
 ### 💡 Enhancements 💡
 - Improved tamplate.yaml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coralogix-aws-shipper"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Coralogix can be configured to receive data directly from your CloudWatch log gr
 | CloudWatchLogGroupName | Provide a comma-separated list of CloudWatch log group names to monitor, for example, (`log-group1`, `log-group2`, `log-group3`). | | :heavy_check_mark: |
 | CloudWatchLogGroupPrefix | Prefix of the CloudWatch log groups that will trigger the lambda, in case that your log groups are `log-group1, log-group2, log-group3` then you can set the value to `log-group`. When using this variable you will not be able to see the log groups as trigger for the lambda. The parameter dose not replace **CloudWatchLogGroupName** parameter | | |
 
+In case your log group name is longer than 70, than in the lambda function you will see the permission for that log group as:
+`allow-trigger-from-<the log group first 65 characters and the last 5 characters>` this is because of length limit in AWS for permission name.
+
 ### SNS Configuration
 
 To receive SNS messages directly to Coralogix, use the `SNSIntegrationTopicARN` parameter. This differs from the above use of `SNSTopicArn`, which notifies based on S3 events.

--- a/custom-resource/index.py
+++ b/custom-resource/index.py
@@ -444,16 +444,10 @@ class ConfigureCloudwatchIntegration:
                 logGroupName=log_group
             )
 
-    @handle_exceptions
     def check_statmentid_length(self, statmentid_prefix):
         updated_prefix = statmentid_prefix
         if len(statmentid_prefix) >= 70: # StatementId length limit is 100
             updated_prefix = statmentid_prefix[:65] + statmentid_prefix[-5:]
-        return updated_prefix
-        if len(statmentid_prefix) >= 70: # StatementId length limit is 100
-            updated_prefix = statmentid_prefix[:65] + statmentid_prefix[-5:]
-        else:
-            updated_prefix = statmentid_prefix
         return updated_prefix
 
     @handle_exceptions

--- a/custom-resource/index.py
+++ b/custom-resource/index.py
@@ -449,6 +449,9 @@ class ConfigureCloudwatchIntegration:
         updated_prefix = statmentid_prefix
         if len(statmentid_prefix) >= 70: # StatementId length limit is 100
             updated_prefix = statmentid_prefix[:65] + statmentid_prefix[-5:]
+        return updated_prefix
+        if len(statmentid_prefix) >= 70: # StatementId length limit is 100
+            updated_prefix = statmentid_prefix[:65] + statmentid_prefix[-5:]
         else:
             updated_prefix = statmentid_prefix
         return updated_prefix

--- a/custom-resource/index.py
+++ b/custom-resource/index.py
@@ -409,10 +409,11 @@ class ConfigureCloudwatchIntegration:
 
         if LambdaPremissionPrefix and LambdaPremissionPrefix != [""]:
             for prefix in LambdaPremissionPrefix:
+                replaced_prefix =  self.check_statmentid_length(prefix)
                 try:
                     self.aws_lambda.add_permission(
                     FunctionName=lambda_arn,
-                    StatementId=f'allow-trigger-from-{prefix.replace("/", "-")}-log-groups',
+                    StatementId=f'allow-trigger-from-{replaced_prefix.replace("/", "-")}-log-groups',
                     Action='lambda:InvokeFunction',
                     Principal='logs.amazonaws.com',
                     SourceArn=f'arn:aws:logs:{region}:{account_id}:log-group:{prefix}*:*',
@@ -427,9 +428,10 @@ class ConfigureCloudwatchIntegration:
             )
             if not LambdaPremissionPrefix or LambdaPremissionPrefix == [""]:
                 if not response.get("subscriptionFilters") or response.get("subscriptionFilters")[0].get("destinationArn") != lambda_arn:
+                    replaced_prefix =  self.check_statmentid_length(log_group)
                     response = self.aws_lambda.add_permission(
                         FunctionName=lambda_arn,
-                        StatementId=f'allow-trigger-from-{log_group.replace("/", "-")}',
+                        StatementId=f'allow-trigger-from-{replaced_prefix.replace("/", "-")}',
                         Action='lambda:InvokeFunction',
                         Principal='logs.amazonaws.com',
                         SourceArn=f'arn:aws:logs:{region}:{account_id}:log-group:{log_group}:*',
@@ -441,6 +443,15 @@ class ConfigureCloudwatchIntegration:
                 filterPattern='',
                 logGroupName=log_group
             )
+
+    @handle_exceptions
+    def check_statmentid_length(self, statmentid_prefix):
+        updated_prefix = statmentid_prefix
+        if len(statmentid_prefix) >= 70: # StatementId length limit is 100
+            updated_prefix = statmentid_prefix[:65] + statmentid_prefix[-5:]
+        else:
+            updated_prefix = statmentid_prefix
+        return updated_prefix
 
     @handle_exceptions
     def update(self):
@@ -466,9 +477,10 @@ class ConfigureCloudwatchIntegration:
                         logGroupName=log_group
                     )
                 if not LambdaPremissionPrefix:
+                    replaced_prefix =  self.check_statmentid_length(log_group)
                     response = self.aws_lambda.remove_permission(
                         FunctionName=lambda_arn,
-                        StatementId=f'allow-trigger-from-{log_group.replace("/", "-")}'
+                        StatementId=f'allow-trigger-from-{replaced_prefix.replace("/", "-")}'
                     )
 
     def handle(self):

--- a/template.yaml
+++ b/template.yaml
@@ -25,7 +25,7 @@ Metadata:
       - kinesis
       - cloudfront
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.0.10
+    SemanticVersion: 1.0.11
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-shipper
 
   AWS::CloudFormation::Interface:


### PR DESCRIPTION
# Description
When user passes a log group longer than 70 characters, then he will hit a limit to the permission length in the cloudwatch integration, Update the StatementId for the cloudwatch integration so if the log group is longer than 70 characters then it will slice it to avoid this issue.
<!-- Please describe the changes you made in a few words or sentences. -->
<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the versions in the SemanticVersion in template.yaml
- [ ] I have updated the CHANGELOG.md
- [ ] I have created necessary PR to Terraform Module Repository (https://github.com/coralogix/terraform-coralogix-aws) if needed
- [ ] This change does not affect any particular component (e.g. it's CI or docs change) 
