### PR TITLE
[CDS-1549] allow matches with govcloud for arn of aws secretmanager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.14 / 2024-01-10
+### 🧰 Bug fixes 🧰
+- Allow matches with arn of aws secretmanager in govcloud, previously only matched with public cloud secretmanager arn
+
 ## v1.0.13 / 2024-11-08
 ### 🧰 Bug fixes 🧰
 - Allow the lambda to use the runtime `provided.al2`, by changing the binary build of cargo to a version that will support it in the Makefile. Add a parameter `FunctionRunTime` to allow users to choose the function runtime

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coralogix-aws-shipper"
-version = "1.0.13"
+version = "1.0.14"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Error> {
 
     // if APIKey provided is an ARN, get the APIKey from Secrets Manager
     let api_key_value = config.api_key.token().to_string();
-    if api_key_value.starts_with("arn:aws:secretsmanager:") {
+    if api_key_value.starts_with("arn:aws") && api_key_value.contains(":secretsmanager") {
         config.api_key = config::get_api_key_from_secrets_manager(&aws_config, api_key_value)
             .await
             .map_err(|e| e.to_string())?;

--- a/template.yaml
+++ b/template.yaml
@@ -25,7 +25,7 @@ Metadata:
       - kinesis
       - cloudfront
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.0.13
+    SemanticVersion: 1.0.14
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-shipper
 
   AWS::CloudFormation::Interface:


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the versions in the SemanticVersion in template.yaml
- [X] I have updated the CHANGELOG.md
- [ ] I have created necessary PR to Terraform Module Repository (https://github.com/coralogix/terraform-coralogix-aws) if needed
- [ ] This change does not affect any particular component (e.g. it's CI or docs change) 
