### PR TITLE
fix: CDS-1747 get rid of iam permissions for shipper custom resource function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v1.1.1 / 2025-12-27
+### 🧰 Bug fixes 🧰
+- cds-1747 - Removed `iam:*` permissions from Shipper, as they were leftover from older versions as the Custom Resource use to be responsible for editing the policy directly
+
 ### v1.1.0 / 2025-12-11
 ### 💡 Enhancements (Breaking) 💡
 - cds-1705 - updated support for dynamic value allocation of Application and Subsystem names based on internal metadata

--- a/template.yaml
+++ b/template.yaml
@@ -1167,12 +1167,6 @@ Resources:
       Timeout: 900
       Policies:
       - Statement:
-        - Sid: IAMaccess
-          Effect: Allow
-          Action:
-            - 'iam:*'
-          Resource: '*'
-      - Statement:
         - Sid: EC2Access
           Effect: Allow
           Action:


### PR DESCRIPTION
# Description

This will remove `iam:*` permissions from Shipper cloudformation template, as they were leftover from older versions as the Custom Resource use to be responsible for editing the policy directly

Fixes CDS-1747 (partially)

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)