### PR TITLE
Fix: CDS-1756 reduce custom-resource function permissions scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v1.1.1 / 2025-12-27
+### 🧰 Bug fixes 🧰
+- cds-1747 - Removed `iam:*` permissions from Shipper, as they were leftover from older versions as the Custom Resource use to be responsible for editing the policy directly
+
 ### v1.1.0 / 2025-12-11
 ### 💡 Enhancements (Breaking) 💡
 - cds-1705 - updated support for dynamic value allocation of Application and Subsystem names based on internal metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v1.1.2 / 2025-12-31
+### 🧰 Bug fixes 🧰
+- cds-1756 - Restricted Lambda `EventSourceMapping` permissions used by custom resource function, so it won't have a wildcard/full resource access
+
 ### v1.1.1 / 2025-12-27
 ### 🧰 Bug fixes 🧰
 - cds-1747 - Removed `iam:*` permissions from Shipper, as they were leftover from older versions as the Custom Resource use to be responsible for editing the policy directly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coralogix-aws-shipper"
-version = "1.1.0"
+version = "1.1.2"
 edition = "2021"
 
 [dependencies]

--- a/template.yaml
+++ b/template.yaml
@@ -1193,7 +1193,7 @@ Resources:
           - lambda:UpdateEventSourceMapping
           - lambda:GetFunctionConfiguration
           - lambda:UpdateFunctionConfiguration
-          Resource: '*'
+          Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*
       - Statement:
         - Sid: S3NotificationPolicy
           Effect: Allow

--- a/template.yaml
+++ b/template.yaml
@@ -1167,12 +1167,6 @@ Resources:
       Timeout: 900
       Policies:
       - Statement:
-        - Sid: IAMaccess
-          Effect: Allow
-          Action:
-            - 'iam:*'
-          Resource: '*'
-      - Statement:
         - Sid: EC2Access
           Effect: Allow
           Action:

--- a/template.yaml
+++ b/template.yaml
@@ -25,7 +25,7 @@ Metadata:
       - kinesis
       - cloudfront
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.1.0
+    SemanticVersion: 1.1.2
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-shipper
 
   AWS::CloudFormation::Interface:


### PR DESCRIPTION
# Description

This will restrict permissions scope for `CustomResourceFunction`, instead of having full access to EventSourceMapping permissions, we'll limit it to region/account scope.

At the same time, we will avoid a circular dependency, when the stack cannot determine the order of resource creation.

# How Has This Been Tested?

1. Deployed CloudFormation template from the latest version / master branch using CloudWatch integration
2. Tested the function verifying it sends the expected data to Coralogix
3. Updated the function with this changeset, restricting permissions
4. Verified the changeset in CloudFormation console
5. Verified the applied stack update in IAM console
6. Tested the function again, verifying it sends the expected data to Coralogix

# Checklist:
- [x] I have updated the versions in the SemanticVersion in template.yaml
- [x] I have updated the CHANGELOG.md
- [x] I have created necessary PR to Terraform Module Repository (https://github.com/coralogix/terraform-coralogix-aws) if needed
- [x] This change does not affect any particular component (e.g. it's CI or docs change) 
