### PR TITLE
fix bug for deploying the integration when bucket name is to long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.4 / 2025-02-19
+### 🧰 Bug fixes 🧰
+- Fixed issue when deploying S3 integration with bucket name longer than 40 characters.
+
 ## v1.3.3 / 2025-02-13
 ### 🧰 Bug fixes 🧰
 - Fixed issue when updating an existing CF stack with S3, CloudTrail, VpcFlow or S3Csv integration type.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coralogix-aws-shipper"
-version = "1.3.3"
+version = "1.3.4"
 edition = "2021"
 
 [dependencies]

--- a/custom-resource/index.py
+++ b/custom-resource/index.py
@@ -123,6 +123,8 @@ class ConfigureS3Integration:
     def handle_lambda_permissions(self, bucket_name_list, lambda_function_arn, function_name, request_type):
         for bucket_name in bucket_name_list.split(","):
             statement_id = f'allow-s3-{bucket_name}-invoke-{function_name}'
+            if len(statement_id) >= 100:
+                statement_id = f"allow-s3-{bucket_name}-invoke-" + statement_id[-5:]
             try:
                 if request_type == 'Delete' or request_type == 'Update':
                     response = self.aws_lambda.remove_permission(

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Metadata:
       - kinesis
       - cloudfront
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.3.3
+    SemanticVersion: 1.3.4
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-shipper
 
   AWS::CloudFormation::Interface:


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the versions in the SemanticVersion in template.yaml
- [x] I have updated the CHANGELOG.md
- [ ] I have created necessary PR to Terraform Module Repository (https://github.com/coralogix/terraform-coralogix-aws) if needed
- [ ] This change does not affect any particular component (e.g. it's CI or docs change) 
