### PR TITLE
update permissions read for git action

### DIFF
--- a/.github/workflows/Changelog.yaml
+++ b/.github/workflows/Changelog.yaml
@@ -14,6 +14,8 @@ on:
 jobs:
   get-label:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     name: get label
     outputs:
       labels: "${{ steps.pr-labels.outputs.labels }}"

--- a/.github/workflows/Documents_Validation.yaml
+++ b/.github/workflows/Documents_Validation.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   check-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     name: Check Documentation formatting and links
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish-rc.yaml
+++ b/.github/workflows/publish-rc.yaml
@@ -16,6 +16,8 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         target:
@@ -89,6 +91,8 @@ jobs:
     needs: build
     if: ${{ github.event_name == 'workflow_dispatch' || success() }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,6 +64,8 @@ jobs:
   validate:
     name: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -87,6 +89,8 @@ jobs:
     needs: validate
     if: ${{ github.event_name == 'workflow_dispatch' || success() }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         target:
@@ -174,6 +178,8 @@ jobs:
     needs: [check_version , build]
     if: ${{ github.event_name == 'workflow_dispatch' || (success() && needs.check_version.outputs.template_updated == 'true' && github.ref == 'refs/heads/master') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       AWS_SERVERLESS_BUCKET: coralogix-serverless-repo
     steps:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -21,6 +21,8 @@ env:
 jobs:
   get-template:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: checkout coralogix-aws-shipper repository

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# Description
Some of our GitHub actions don't restrict the permissions of the action, added permissions action of read so for the actions that dont need write will not have this permission by default
<!-- Please describe the changes you made in a few words or sentences. -->
<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the versions in the SemanticVersion in template.yaml
- [ ] I have updated the CHANGELOG.md
- [ ] I have created necessary PR to Terraform Module Repository (https://github.com/coralogix/terraform-coralogix-aws) if needed
- [x] This change does not affect any particular component (e.g. it's CI or docs change) 
