### PR TITLE
CDS-2326 - add kms support for S3 buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.11 / 2025-08-11
+### 💡 Enhancements 💡
+- Add support for S3 bucket KMS key using `S3BucketKMSKeyARN`
+
 ## v1.3.10 / 2025-08-04
 ### 🧰 Bug fixes 🧰
 - Fixed issue when deploying S3 integration with bucket names containing periods (e.g., `my-bucket.example.com`). The custom resource now sanitizes bucket names by replacing periods with underscores in Lambda permission statement IDs to comply with AWS naming constraints.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ If you don’t want to send data directly as it enters S3, you can also use SNS/
 | NewlinePattern | Enter a regular expression to detect a new log line for multiline logs. For example, \n(?=\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3}).                                                                         |                                          |                    |
 | SNSTopicArn    | The ARN for the SNS topic that contains the SNS subscription responsible for retrieving logs from Amazon S3.                                                                                      |                                          |                    |
 | SQSTopicArn    | The ARN for the SQS queue that contains the SQS subscription responsible for retrieving logs from Amazon S3.                                                                                      |                                          |                    |
-| CSVDelimiter   | Specify a single character to be used as a delimiter when ingesting a CSV file with a header line. This value is applicable when the S3Csv integration type is selected, such as, “,” or ” “. | ,                                        |                    |
+| CSVDelimiter   | Specify a single character to be used as a delimiter when ingesting a CSV file with a header line. This value is applicable when the S3Csv integration type is selected, such as, "," or " ". | ,                                        |                    |
+| S3BucketKMSKeyARN | The ARN of the KMS key used to encrypt objects in the S3 bucket. Required if using SSE-KMS encryption on the S3 bucket. |                                          |                    |
 
 ### CloudWatch configuration
 

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Metadata:
       - kinesis
       - cloudfront
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.3.10
+    SemanticVersion: 1.3.11
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-shipper
 
   AWS::CloudFormation::Interface:

--- a/template.yaml
+++ b/template.yaml
@@ -48,6 +48,7 @@ Metadata:
           - S3BucketName
           - S3KeyPrefix
           - S3KeySuffix
+          - S3BucketKMSKeyARN
           - NewlinePattern
           - SNSTopicArn
           - SQSTopicArn
@@ -220,6 +221,13 @@ Parameters:
       The AWS S3 path suffix to watch. This value is ignored
       when the SNSTopicArn parameter is provided.
     MaxLength: 1024
+    Default: ''
+
+  S3BucketKMSKeyARN:
+    Type: String
+    Description: |
+      The ARN of the KMS key used to encrypt objects in the S3 bucket.
+      Required if using SSE-KMS encryption on the S3 bucket.
     Default: ''
 
   FunctionMemorySize:
@@ -528,6 +536,7 @@ Conditions:
   IsLambdaAssumeRoleEnable: !Not [!Equals [!Ref LambdaAssumeRoleARN, '']]
   ExecutionRoleARNIsSet: !Not [!Equals [!Ref ExecutionRoleARN, '']]
   ReservedConcurrentExecutionsIsSet: !Not [!Equals [!Ref ReservedConcurrentExecutions, 0]]
+  S3BucketKMSKeyARNIsSet: !Not [!Equals [!Ref S3BucketKMSKeyARN, '']]
 
   # TelemetryModeIsLogs: !Equals [!Ref TelemetryMode, logs]
   TelemetryModeIsMetrics: !Equals [!Ref TelemetryMode, metrics]
@@ -691,6 +700,15 @@ Resources:
               Action:
                 - 's3:GetObject'
               Resource: arn:aws:s3:::*
+            - !Ref AWS::NoValue
+
+          # KMS Policy for S3 bucket encryption
+          - !If
+            - S3BucketKMSKeyARNIsSet
+            - Effect: Allow
+              Action:
+                - 'kms:Decrypt'
+              Resource: !Ref S3BucketKMSKeyARN
             - !Ref AWS::NoValue
           # SQS Policy
           - !If


### PR DESCRIPTION
# Description

This PR adds KMS support for S3 buckets. Adds new parameter `S3BucketKMSKeyARN` to specify the KMS key ARN

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the versions in the SemanticVersion in template.yaml
- [x] I have updated the CHANGELOG.md
- [ ] I have created necessary PR to Terraform Module Repository (https://github.com/coralogix/terraform-coralogix-aws) if needed
- [ ] This change does not affect any particular component (e.g. it's CI or docs change) 
